### PR TITLE
Adding Google TV support

### DIFF
--- a/{{cookiecutter.out_dir}}/android/app/src/main/AndroidManifest.xml
+++ b/{{cookiecutter.out_dir}}/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,10 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <!-- Google TV -->
+    <uses-feature android:name="android.software.leanback" android:required="false" />
+    <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
+
     <application
         android:label="{{ cookiecutter.product_name }}"
         android:name="${applicationName}"
@@ -37,6 +41,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER"/>   <!-- Google TV -->
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.


### PR DESCRIPTION
Adds Google TV support. These changes won't affect any builds for normal android, will just enable apk to work on Google TV devices as well.