### PR TITLE
geolocator foreground/background service additions

### DIFF
--- a/{{cookiecutter.out_dir}}/android/app/src/main/AndroidManifest.xml
+++ b/{{cookiecutter.out_dir}}/android/app/src/main/AndroidManifest.xml
@@ -9,8 +9,13 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- Geolocator background/foreground service permissions -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <!-- Google TV -->
     <uses-feature android:name="android.software.leanback" android:required="false" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
@@ -18,6 +23,7 @@
     <application
         android:label="{{ cookiecutter.product_name }}"
         android:name="${applicationName}"
+        android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher">
         <meta-data
                 android:name="io.flutter.embedding.android.EnableImpeller"

--- a/{{cookiecutter.out_dir}}/pubspec.yaml
+++ b/{{cookiecutter.out_dir}}/pubspec.yaml
@@ -28,8 +28,8 @@ dependency_overrides:
 # {% endif %}
 
 # {% if 'flet_geolocator' in cookiecutter.flutter.dependencies %}
-  geolocator: ^12.0.0
-  geolocator_android: ^4.6.0
+#  geolocator: ^12.0.0
+#  geolocator_android: ^4.6.0
 # {% endif %}
 
 dev_dependencies:


### PR DESCRIPTION
Adds needed permission to AndroidManifest.xml and comments out geolocator in pubspec.yaml as this was updated in packages/flet_geolocator/pubspec.yaml