### PR TITLE
Set `CFBundleName` value to project's name in macos `Info.plist`

### DIFF
--- a/{{cookiecutter.out_dir}}/macos/Runner/Info.plist
+++ b/{{cookiecutter.out_dir}}/macos/Runner/Info.plist
@@ -13,7 +13,7 @@
 		<key>CFBundleInfoDictionaryVersion</key>
 		<string>6.0</string>
 		<key>CFBundleName</key>
-		<string>$(PRODUCT_NAME)</string>
+		<string>{{ cookiecutter.project_name }}</string>
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
Issue: https://github.com/flet-dev/flet/issues/5062#issuecomment-2717217879