### PR TITLE
v1: Support 16KB pages for apps targeting Android 15+

### DIFF
--- a/{{cookiecutter.out_dir}}/pubspec.yaml
+++ b/{{cookiecutter.out_dir}}/pubspec.yaml
@@ -32,16 +32,19 @@ dependency_overrides:
   serious_python:
     git:
       url: https://github.com/flet-dev/serious-python.git
-      ref: hidden-files-fix
+      ref: android-16k
       path: src/serious_python
 
   wakelock_plus: ^1.2.10
   web: ^1.0.0
   window_manager: ^0.4.3
-  webview_flutter_android: ^4.0.0
 
 # {% if 'flet_audio_recorder' in cookiecutter.flutter.dependencies %}
   record: ^5.1.1
+# {% endif %}
+
+# {% if 'flet_webview' in cookiecutter.flutter.dependencies %}
+  webview_flutter_android: ^4.0.0
 # {% endif %}
 
 # {% if 'flet_geolocator' in cookiecutter.flutter.dependencies %}


### PR DESCRIPTION
Changed the serious_python dependency to use the 'android-16k' ref instead of 'hidden-files-fix'. Moved webview_flutter_android under a conditional block for flet_webview dependency.