### PR TITLE
Update serious_python dependency ref to cxx-20

### DIFF
--- a/{{cookiecutter.out_dir}}/pubspec.yaml
+++ b/{{cookiecutter.out_dir}}/pubspec.yaml
@@ -43,7 +43,7 @@ dependency_overrides:
   serious_python:
     git:
       url: https://github.com/flet-dev/serious-python.git
-      ref: app-zip-windows-fix
+      ref: cxx-20
       path: src/serious_python
 
   package_info_plus: ^9.0.0


### PR DESCRIPTION
Changed the git reference for the serious_python dependency from 'app-zip-windows-fix' to 'cxx-20' in pubspec.yaml to use the latest updates from that branch.