### PR TITLE
Make Flutter deps single-source via `flet` package

### DIFF
--- a/{{cookiecutter.out_dir}}/pubspec.yaml
+++ b/{{cookiecutter.out_dir}}/pubspec.yaml
@@ -21,8 +21,6 @@ dependencies:
   path: ^1.9.0
   window_manager: ^0.5.1
 
-
-
 # {% if 'flet_geolocator' in cookiecutter.flutter.dependencies %}
 #  geolocator: ^12.0.0
 #  geolocator_android: ^4.6.0

--- a/{{cookiecutter.out_dir}}/pubspec.yaml
+++ b/{{cookiecutter.out_dir}}/pubspec.yaml
@@ -13,41 +13,15 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
 
+  flet: 0.80.5
   serious_python: 0.9.9
 
-  battery_plus: ^7.0.0
-  connectivity_plus: ^7.0.0
-  cupertino_icons: ^1.0.6
-  device_info_plus: ^12.3.0
-  file_picker: ^10.3.10
   package_info_plus: ^9.0.0
   path_provider: ^2.1.4
   path: ^1.9.0
-  screen_brightness: ^2.1.7
-  sensors_plus: ^7.0.0
-  shared_preferences: 2.5.3
-  share_plus: ^12.0.1
-  url_launcher: 6.3.2
-  wakelock_plus: ^1.4.0
   window_manager: ^0.5.1
-  
-dependency_overrides:
-  flet: 0.80.5
 
-  # flet:
-  #   git:
-  #     path: packages/flet
-  #     ref: main
-  #     url: https://github.com/flet-dev/flet.git
 
-  # serious_python:
-  #   git:
-  #     url: https://github.com/flet-dev/serious-python.git
-  #     ref: cxx-20
-  #     path: src/serious_python
-
-  package_info_plus: ^9.0.0
-  wakelock_plus: ^1.4.0
 
 # {% if 'flet_geolocator' in cookiecutter.flutter.dependencies %}
 #  geolocator: ^12.0.0


### PR DESCRIPTION
Removes redundant Flutter plugin declarations from the build template and makes `flet` flutter package the single source of truth for core plugin versions. Managing twice thesame versions is a difficult task.
I gave it a try with `FilePicker` and `Battery` examples, and it worked:
```bash
uvx --no-cache --with flet-cli==0.80.5 --with flet==0.80.5 flet debug android -d emulator-5554 -v --template-ref flet-direct-dep
``` 

Also, we should no longer tweak the versions/git-refs of serious-python or flet (through `dependency_overrides` for example), as it leads to leftovers, which later on [break builds](https://github.com/ndonkoHenri/filepicker_bug/actions/runs/21624666022/job/62321728315#step:5:82). Instead, `[tool.flet.flutter.pubspec]` in pyproject can be defined, and flet-build handle accordingly at build/run time. 
Docs: https://product-project-artifact.flet-docs.pages.dev/publish/#flutter-dependencies

The exception is of course, when legitly bumping flet or serious-python official-version, for example when creating a new branch for a new flet release.

