### PR TITLE
fix: expose `FLET_ASSETS_DIR` environment variable in non-web environments

### DIFF
--- a/{{cookiecutter.out_dir}}/lib/main.dart
+++ b/{{cookiecutter.out_dir}}/lib/main.dart
@@ -207,6 +207,10 @@ Future prepareApp() async {
     }
   }
 
+  if (!kIsWeb && assetsDir.isNotEmpty) {
+    environmentVariables["FLET_ASSETS_DIR"] = assetsDir;
+  }
+
   return "";
 }
 


### PR DESCRIPTION
Fixes https://github.com/flet-dev/flet/issues/5692